### PR TITLE
Add a pool of buffers so that RAMs are persistent across instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,17 @@ var AbstractRandomAccess = require('abstract-random-access')
 
 module.exports = RandomAccessMemory
 
+var pool = {}
+
 function RandomAccessMemory (buf) {
-  if (!(this instanceof RandomAccessMemory)) return new RandomAccessMemory(buf)
+  if (!(this instanceof RandomAccessMemory)) {
+    if (typeof buf === 'string' && buf in pool) return pool[buf]
+    return new RandomAccessMemory(buf)
+  }
   AbstractRandomAccess.call(this)
   this.buffer = (buf && Buffer.isBuffer(buf)) ? buf : new Buffer(0)
   this.length = this.buffer.length
+  if (typeof buf === 'string') pool[buf] = this
 }
 
 inherits(RandomAccessMemory, AbstractRandomAccess)


### PR DESCRIPTION
This ensures that multiple instances will share a buffer. It's a bit temperamental though, because if you use the `new` syntax, it won't work.