### PR TITLE
fix buffers array in _unlink, add unlink test

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ module.exports = class RAM extends RandomAccess {
   }
 
   _unlink (req) {
-    this._buffers = []
+    this.buffers = []
     this.length = 0
     req.callback(null, null)
   }

--- a/test.js
+++ b/test.js
@@ -137,3 +137,18 @@ test('clone', function (t) {
     })
   })
 })
+
+test('unlink', function (t) {
+  t.plan(4)
+
+  const file = new RAM()
+
+  file.write(0, Buffer.from('hello'), function (err) {
+    t.absent(err, 'no error')
+    file.unlink(function (err) {
+      t.absent(err, 'no error')
+      t.is(0, file.buffers.length, 'no buffer')
+      t.is(0, file.length, 'no length')
+    })
+  })
+})


### PR DESCRIPTION
A small fix and test for resetting the `.buffers` property in `_unlink`.